### PR TITLE
Fix `emailImpersonatedUser` reference on REST API

### DIFF
--- a/content/en/dev-reference/rest-apis/apps-api.md
+++ b/content/en/dev-reference/rest-apis/apps-api.md
@@ -133,9 +133,9 @@ Developer users or users with the appropriate permissions, such as the "manage g
 
 - **`username`**: Your own username for authentication.
 - **`password`**: Your own password for authentication.
-- **`adminUserEmail`**: The email address of the user you wish to impersonate.
+- **`emailImpersonatedUser`**: The email address of the user you wish to impersonate.
 
-When you provide the **`adminUserEmail`** field in the request body, you will log in as the specified user with their permissions and privileges. This feature is particularly valuable for testing and administrative purposes, allowing authorized users to perform actions on behalf of different users.
+When you provide the **`emailImpersonatedUser`** field in the request body, you will log in as the specified user with their permissions and privileges. This feature is particularly valuable for testing and administrative purposes, allowing authorized users to perform actions on behalf of different users.
 
 Ensure that user impersonation is used responsibly and only by users with the necessary permissions to prevent any unauthorized actions within the system.
 


### PR DESCRIPTION
## Summary

The key `emailImpersonatedUser` was mistaken by `adminUserEmail` on the request for getting an impersonated user token.

## Solution

The key name was replaced by the correct one: `emailImpersonatedUser`.

## Testing

- Using `emailImpersonatedUser` results on the correct response for impersonating an user

```bash
curl -sX POST 'https://devtest.slingrs.io/dev/runtime/api/auth/login' \
    -H 'Content-Type: application/json' \
    -d '{"email":"jmespinosa@slingr.io", "password":"******","emailImpersonatedUser":"dgaviola@slingr.io"}'
```

- Using `adminUserEmail` results on a normal login, not impersonating an user. It acts as like that because `emailImpersonatedUser` isn't present on the body request.

```bash
curl -sX POST 'https://devtest.slingrs.io/dev/runtime/api/auth/login' \
    -H 'Content-Type: application/json' \
    -d '{"email":"jmespinosa@slingr.io", "password":"******","adminUserEmail":"dgaviola@slingr.io"}'
```
