### PR TITLE
Fixed wrapper `each` method description

### DIFF
--- a/content/en/dev-reference/scripting/sys-data.md
+++ b/content/en/dev-reference/scripting/sys-data.md
@@ -2160,7 +2160,7 @@ Iterate over all elements in the list.
 
 | Name  | Type  | Required | Description |
 |---|---|---|---|
-callback|function|yes|The function to that will process all elements. It will receive the element wrapper as parameter and should return **`true`** if the element has to be removed or **`false`** otherwise.
+callback|function|yes|The function to that will process all elements. It will receive two parameters: the wrapper element and the current index of the iteration. In order to stop iteration it is possible to return `false` explicitly.
 
 ##### Exceptions
 


### PR DESCRIPTION
Wrapper method `each()` has a wrong description. It describes the expected action of the callback function from the `remove()` wrapper method.

The description was fixed using the old platform documentation as a reference.