### PR TITLE
Correct pricing page link

### DIFF
--- a/content/en/platform-ref/slingr-dev-portal/managing-apps.md
+++ b/content/en/platform-ref/slingr-dev-portal/managing-apps.md
@@ -44,7 +44,7 @@ Then, you will be asked to complete the following fields:
   - **`Slingr Business Plan`**: Here you can start to have an isolated production environment with a fixed price, it gives greater possibilities than the previous plans.
   - **`Slingr Enterprise Plan`**: This is a usage-based plan meant for applications in production environments that need dedicated resources and outstanding performance. There are no limitations with the **Slingr Enterprise Plan**.
 
-  You can see the full comparison in [Pricing and Billing](https://www.slingr.io/pricing).
+  You can see the full comparison in [Pricing and Billing](https://www.slingr.io/platform/pricing).
 
 - **`Template`**: You can choose to start from scratch, with an empty app, or you can choose one of the available templates. Here you will find global templates created by other people, or you can also create your own templates. See [App templates](#app-templates) for more information.
 

--- a/content/en/platform-ref/slingr-dev-portal/pricing-and-billing.md
+++ b/content/en/platform-ref/slingr-dev-portal/pricing-and-billing.md
@@ -11,7 +11,7 @@ menu:
 toc: true
 weight: 4
 ---
-Pricing of the platform is based on apps. [You can check the pricing here](https://www.slingr.io/pricing).
+Pricing of the platform is based on apps. [You can check the pricing here](https://www.slingr.io/platform/pricing).
 
 Each app will have a corresponding subscription, which can be associated with any of the four products we offer:
 


### PR DESCRIPTION
Self-explanatory. Once I found the issue on the first page, I searched for and corrected the other which had it.

(I'm making the edits in the github UI, so pardon the clumsiness of having two separate commits, with different commit msgs, and no name on the branch.)